### PR TITLE
Improve metadata analyzer with auto apply

### DIFF
--- a/cacd_readme.md
+++ b/cacd_readme.md
@@ -45,8 +45,12 @@ cacd-analyzer meu-vault/ -t taxonomia_cacd.yaml
 # 2. Revisar arquivo 'cacd_feedback.md' no vault
 # (marcar [x] para aprovar sugestões)
 
-# 3. Aplicar mudanças aprovadas  
+# 3. Aplicar mudanças aprovadas
 cacd-analyzer meu-vault/ -t taxonomia_cacd.yaml -m process
+
+# (Opcional) Aplicar automaticamente sugestões de alta confiança
+#   0.8 indica confiança mínima
+cacd-analyzer meu-vault/ -t taxonomia_cacd.yaml --auto-apply 0.8
 
 # 4. Gerar relatório de estudos
 cacd-analyzer meu-vault/ -t taxonomia_cacd.yaml -m report
@@ -121,6 +125,7 @@ O programa gera tags específicas por área:
 ```bash
 --min-confidence 0.5  # Confiança mínima (0.0-1.0)
 -v                    # Saída verbosa para debug
+--auto-apply 0.8      # Aplica sugestões automaticamente (>= confiança)
 --help               # Ajuda completa
 ```
 

--- a/cacd_usage_guide.md
+++ b/cacd_usage_guide.md
@@ -96,6 +96,9 @@ cacd-analyzer vault/ -t taxonomia.yaml --min-confidence 0.5
 
 # Saída verbosa para debugging
 cacd-analyzer vault/ -t taxonomia.yaml -v
+
+# Aplicar automaticamente sugestões acima de 0.8 de confiança
+cacd-analyzer vault/ -t taxonomia.yaml --auto-apply 0.8
 ```
 
 ## 📊 Metadados Gerados


### PR DESCRIPTION
## Summary
- improve suggestions of related notes by scoring overlap and metadata
- add `auto_apply_metadata` for applying changes automatically
- introduce `--auto-apply` CLI argument
- describe new option in docs
- fix backup handling

## Testing
- `python3 cacd_test_script.py`

------
https://chatgpt.com/codex/tasks/task_e_683e4e7f1700832ebd53208ea77805d5